### PR TITLE
935343 [Dev] Add tab support for Visual Studio and Visual Studio code in toolkit getting started page

### DIFF
--- a/maui-toolkit/Button/Getting-Started.md
+++ b/maui-toolkit/Button/Getting-Started.md
@@ -188,7 +188,7 @@ using Syncfusion.Maui.Toolkit.Buttons;
 
 {% endtabs %}
 {% endtabcontent %}
-{% tabcontent Visual Studio Code %}
+{% endtabcontents %}
 
 ## Button icon
 
@@ -218,9 +218,6 @@ button.CornerRadius= 2;
 
 {% endhighlight %}
 {% endtabs %}
-
-{% endtabcontent %}
-{% endtabcontents %}
 
 ![.NET MAUI Button with button icon.](images/getting-started/net-maui-button-with-icon.png)
 

--- a/maui-toolkit/Button/Getting-Started.md
+++ b/maui-toolkit/Button/Getting-Started.md
@@ -11,22 +11,105 @@ documentation: ug
 
 This section guides you through setting up and configuring a [Button](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Buttons.SfButton.html) in your .NET MAUI application. Follow the steps below to add a basic Button to your project.
 
+{% tabcontents %}
+{% tabcontent Visual Studio %}
+
 ## Prerequisites
 
 Before proceeding, ensure the following are in place:
 
 1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
-2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later) or Visual Studio Code. For Visual Studio Code users, ensure that the .NET MAUI workload is installed and configured as described [here](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code).
+2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later).
 
 ## Step 1: Create a New .NET MAUI Project
-
-### Visual Studio
 
 1. Go to **File > New > Project** and choose the **.NET MAUI App** template.
 2. Name the project and choose a location. Then, click **Next**.
 3. Select the .NET framework version and click **Create**.
 
-### Visual Studio Code
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit Package
+
+1. In **Solution Explorer,** right-click the project and choose **Manage NuGet Packages.**
+2. Search for [Syncfusion.Maui.Toolkit](https://www.nuget.org/packages/Syncfusion.Maui.Toolkit/) and install the latest version.
+3. Ensure the necessary dependencies are installed correctly, and the project is restored.
+
+## Step 3: Register the handler
+
+In the MauiProgram.cs file, register the handler for Syncfusion<sup>®</sup> Toolkit.
+
+{% tabs %}
+{% highlight C# tabtitle="MauiProgram.cs" hl_lines="1 9" %}
+using Syncfusion.Maui.Toolkit.Hosting;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .ConfigureSyncfusionToolkit()
+            .UseMauiApp<App>()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            });
+
+        return builder.Build();
+    }
+}
+
+{% endhighlight %}
+{% endtabs %} 
+
+## Step 4: Add a Basic Button control
+
+Step 1. To initialize the control, import the `Syncfusion.Maui.Toolkit.Buttons` namespace into your code. 
+
+Step 2: Initialize [SfButton](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Buttons.SfButton.html) control.
+
+{% tabs %}
+
+{% highlight xaml %}
+<ContentPage 
+    xmlns:buttons="clr-namespace:Syncfusion.Maui.Toolkit.Buttons;assembly=Syncfusion.Maui.Toolkit">
+    <ContentPage.Content> 
+	 	<buttons:SfButton x:Name="button" />
+	</ContentPage.Content> 
+</ContentPage>
+
+{% endhighlight %}
+
+{% highlight C# %}
+
+using Syncfusion.Maui.Toolkit.Buttons;
+
+	public partial class MainPage : ContentPage
+	{ 
+		public MainPage()
+		{   
+			InitializeComponent();
+			SfButton button = new SfButton();
+			this.Content = button;
+		}  
+	}  
+
+{% endhighlight %}
+
+{% endtabs %}
+
+{% endtabcontent %}
+{% tabcontent Visual Studio Code %}
+
+## Prerequisites
+
+Before proceeding, ensure the following are set up:
+
+1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later is installed.
+2. Set up a .NET MAUI environment with Visual Studio Code.
+3. Ensure that the .NET MAUI extension is installed and configured as described [here.](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code)
+
+## Step 1: Create a New .NET MAUI Project
 
 1. Open the Command Palette by pressing **Ctrl+Shift+P** and type **.NET:New Project** and press Enter.
 2. Choose the **.NET MAUI App** template.
@@ -35,12 +118,6 @@ Before proceeding, ensure the following are in place:
 
 ## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit Package
 
-### Visual Studio
-1. In **Solution Explorer,** right-click the project and choose **Manage NuGet Packages.**
-2. Search for [Syncfusion.Maui.Toolkit](https://www.nuget.org/packages/Syncfusion.Maui.Toolkit/) and install the latest version.
-3. Ensure the necessary dependencies are installed correctly, and the project is restored.
-
-### Visual Studio Code
 1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
 2. Ensure you're in the project root directory where your .csproj file is located.
 3. Run the command `dotnet add package Syncfusion.Maui.Toolkit` to install the Syncfusion<sup>®</sup> .NET MAUI Toolkit NuGet package.
@@ -110,6 +187,8 @@ using Syncfusion.Maui.Toolkit.Buttons;
 {% endhighlight %}
 
 {% endtabs %}
+{% endtabcontent %}
+{% tabcontent Visual Studio Code %}
 
 ## Button icon
 
@@ -139,6 +218,9 @@ button.CornerRadius= 2;
 
 {% endhighlight %}
 {% endtabs %}
+
+{% endtabcontent %}
+{% endtabcontents %}
 
 ![.NET MAUI Button with button icon.](images/getting-started/net-maui-button-with-icon.png)
 

--- a/maui-toolkit/Carousel-View/Getting-Started.md
+++ b/maui-toolkit/Carousel-View/Getting-Started.md
@@ -11,21 +11,114 @@ documentation: ug
 
 This section guides you through setting up and configuring a [Carousel](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.CarouselView.SfCarousel.html) in your .NET MAUI application. Follow the steps below to add a basic Carousel to your project.
 
+{% tabcontents %}
+{% tabcontent Visual Studio %}
+
 ## Prerequisites
 
 Before proceeding, ensure the following are setup:
 1. Ensure [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later is installed.
-2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later) or Visual Studio Code. For Visual Studio Code users, ensure that the .NET MAUI workload is installed and configured as described [here](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code).
+2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later).
 
 ## Step 1: Create a New .NET MAUI Project
-
-### Visual Studio
 
 1. Go to **File > New > Project** and choose the **.NET MAUI App** template.
 2. Name the project and choose a location. Click **Next**.
 3. Select the .NET framework version and click **Create**.
 
-### Visual Studio Code
+## Step 2: Install the Syncfusion<sup>®</sup> .NET MAUI Toolkit Package
+
+1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
+2. Search for [Syncfusion.Maui.Toolkit](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.html) and install the latest version.
+3. Ensure the necessary dependencies are installed correctly, and the project is restored.
+
+## Step 3: Register the handler
+
+In the **MauiProgram.cs** file, register the handler for Syncfusion<sup>®</sup> Toolkit.
+
+{% tabs %}
+
+{% highlight C# tabtitle="MauiProgram.cs" hl_lines="1 9" %}
+
+    using Syncfusion.Maui.Toolkit.Hosting;
+
+    public static class MauiProgram
+    {
+	    public static MauiApp CreateMauiApp()
+	    {
+	        var builder = MauiApp.CreateBuilder();
+		    builder
+			    .ConfigureSyncfusionToolkit()
+			    .UseMauiApp<App>()
+			    .ConfigureFonts(fonts =>
+			    {
+				    fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+				    fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+			    });
+
+		    return builder.Build();
+	    }
+    }
+
+{% endhighlight %}
+
+{% endtabs %} 
+
+## Step 4: Add a Basic Carousel
+
+1. To initialize the control, import the `Syncfusion.Maui.Toolkit.Carousel` namespace into your code.
+
+2. Initialize [SfCarousel](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Carousel.SfCarousel.html)
+
+{% tabs %}
+
+{% highlight xaml %}
+
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:carousel="clr-namespace:Syncfusion.Maui.Toolkit.Carousel;assembly=Syncfusion.Maui.Toolkit"
+             xmlns:local="clr-namespace:CarouselSample"
+             x:Class="CarouselSample.MainPage">
+    <ContentPage.Content> 
+        <carousel:SfCarousel />
+    </ContentPage.Content>  
+</ContentPage>
+	
+{% endhighlight %}
+
+{% highlight C# %}
+
+using Syncfusion.Maui.Toolkit.Carousel;
+namespace CarouselGettingStarted
+{
+    public partial class MainPage : ContentPage
+    {
+        public MainPage()
+        {
+            InitializeComponent();           
+            SfCarousel carousel = new SfCarousel();
+            this.Content = carousel;
+        }
+    }   
+}
+
+{% endhighlight %}
+
+{% endtabs %}
+
+{% endtabcontent %}
+{% tabcontent Visual Studio Code %}
+
+## Prerequisites
+
+Before proceeding, ensure the following are set up:
+
+1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later is installed.
+2. Set up a .NET MAUI environment with Visual Studio Code.
+3. Ensure that the .NET MAUI extension is installed and configured as described [here](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code).
+
+## Step 1: Create a New .NET MAUI Project
 
 1. Open the command palette by pressing `Ctrl+Shift+P` and type **.NET: New Project** and press **Enter**.
 2. Choose the **.NET MAUI App** template.
@@ -33,14 +126,6 @@ Before proceeding, ensure the following are setup:
 4. Choose **Create project**.
 
 ## Step 2: Install the Syncfusion<sup>®</sup> .NET MAUI Toolkit Package
-
-### Visual Studio
-
-1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
-2. Search for [Syncfusion.Maui.Toolkit](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.html) and install the latest version.
-3. Ensure the necessary dependencies are installed correctly, and the project is restored.
-
-### Visual Studio Code
 
 1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (back tick) to open the integrated terminal in Visual Studio Code.
 2. Ensure you're in the project root directory where your .csproj file is located.
@@ -121,6 +206,9 @@ namespace CarouselGettingStarted
 {% endhighlight %}
 
 {% endtabs %}
+
+{% endtabcontent %}
+{% endtabcontents %}
 
 ## Step 5: Populate Carousel Items in .NET MAUI Carousel
 

--- a/maui-toolkit/Carousel-View/Getting-Started.md
+++ b/maui-toolkit/Carousel-View/Getting-Started.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting started with .NET MAUI Carousel View control | Syncfusion<sup>®</sup>
+title: Getting started with .NET MAUI Carousel View | Syncfusion<sup>®</sup>
 description: Learn how to set up, configure, and use the Syncfusion<sup>®</sup> .NET MAUI Carousel View (SfCarousel) control in your cross-platform applications.
 platform: maui
 control: Carousel

--- a/maui-toolkit/Chips/Getting-Started.md
+++ b/maui-toolkit/Chips/Getting-Started.md
@@ -11,22 +11,90 @@ documentation: ug
 
 This section provides instructions for setting up and configuring Chips control [Chips](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Chips.html) in your .NET MAUI application. Follow the steps below to integrate a basic Chips component into your project.
 
+{% tabcontents %}
+{% tabcontent Visual Studio %}
+
 ## Prerequisites
 
 Before proceeding, ensure the following are setup:
 
 1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
-2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later) or Visual Studio Code. For Visual Studio Code users, ensure that the .NET MAUI workload is installed and configured as described [here](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code).
+2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later)
 
 ## Step 1: Create a New .NET MAUI Project
-
-### Visual Studio
 
 1. Go to **File > New > Project** and choose the **.NET MAUI App** template.
 2. Name the project and choose a location. Then, click **Next**.
 3. Select the .NET framework version and click **Create**.
 
-### Visual Studio Code
+## Step 2: Install the Syncfusion<sup>®</sup> .NET MAUI Toolkit Package
+
+1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
+2. Search for [Syncfusion.Maui.Toolkit](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.html) and install the latest version.
+3. Ensure the necessary dependencies are installed correctly, and the project is restored.
+
+## Step 3: Register the Handler 
+
+In the **MauiProgram.cs file**, register the handler for Syncfusion<sup>®</sup> Toolkit.
+
+{% highlight c# hl_lines="1 9" %}
+
+using Syncfusion.Maui.Toolkit.Hosting;
+public static class MauiProgram
+{
+	public static MauiApp CreateMauiApp()
+	{
+		var builder = MauiApp.CreateBuilder();
+		builder
+		.UseMauiApp<App>()
+		.ConfigureSyncfusionToolkit()
+		.ConfigureFonts(fonts =>
+		{
+			fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+		});
+
+		return builder.Build();
+	}      
+}
+   
+{% endhighlight %} 
+
+## Step 4: Add a .NET MAUI Chips control
+
+Step 1. To initialize the control, import the `Syncfusion.Maui.Toolkit.Chips` namespace into your code.
+
+Step 2. Initialize `SfChip` class.
+
+{% tabs %}
+
+{% highlight xaml %}
+	
+	xmlns:ChipControl="clr-namespace:Syncfusion.Maui.Toolkit.Chips;assembly=Syncfusion.Maui.Toolkit"
+       
+{% endhighlight %}
+
+{% highlight c# %}
+
+    using Syncfusion.Maui.Toolkit.Chips;
+
+{% endhighlight %}
+
+{% endtabs %}
+
+Step 3: Set the control to content in `ContentPage.`
+
+{% endtabcontent %}
+{% tabcontent Visual Studio Code %}
+
+## Prerequisites
+
+Before proceeding, ensure the following are set up:
+
+1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later is installed.
+2. Set up a .NET MAUI environment with Visual Studio Code.
+3. Ensure that the .NET MAUI extension is installed and configured as described [here.](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code)
+
+## Step 1: Create a New .NET MAUI Project
 
 1. Open the Command Palette by pressing **Ctrl+Shift+P** and type **.NET:New Project** and press Enter.
 2. Choose the **.NET MAUI App** template.
@@ -35,12 +103,6 @@ Before proceeding, ensure the following are setup:
 
 ## Step 2: Install the Syncfusion<sup>®</sup> .NET MAUI Toolkit Package
 
-### Visual Studio
-1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
-2. Search for [Syncfusion.Maui.Toolkit](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.html) and install the latest version.
-3. Ensure the necessary dependencies are installed correctly, and the project is restored.
-
-### Visual Studio Code
 1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
 2. Ensure you're in the project root directory where your .csproj file is located.
 3. Run the command `dotnet add package Syncfusion.Maui.Toolkit` to install the Syncfusion<sup>®</sup> .NET MAUI Toolkit NuGet package.
@@ -95,6 +157,9 @@ Step 2. Initialize `SfChip` class.
 {% endtabs %}
 
 Step 3: Set the control to content in `ContentPage.`
+
+{% endtabcontent %}
+{% endtabcontents %}
 
 ## For SfChip
 

--- a/maui-toolkit/NumericEntry/Getting-Started.md
+++ b/maui-toolkit/NumericEntry/Getting-Started.md
@@ -11,7 +11,7 @@ documentation: ug
 
 This section guides you through setting up and configuring a [Numeric Entry](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.NumericEntry.SfNumericEntry.html) in your .NET MAUI application. Follow the steps below to add a basic Numeric Entry to your project.
 
-{% tabcontents %}
+{% tabcontents %} 
 {% tabcontent Visual Studio %}
 
 ## Prerequisites

--- a/maui-toolkit/NumericEntry/Getting-Started.md
+++ b/maui-toolkit/NumericEntry/Getting-Started.md
@@ -11,22 +11,101 @@ documentation: ug
 
 This section guides you through setting up and configuring a [Numeric Entry](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.NumericEntry.SfNumericEntry.html) in your .NET MAUI application. Follow the steps below to add a basic Numeric Entry to your project.
 
+{% tabcontents %}
+{% tabcontent Visual Studio %}
+
 ## Prerequisites
 
 Before proceeding, ensure the following are in place:
 
 1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
-2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later) or Visual Studio Code. For Visual Studio Code users, ensure that the .NET MAUI workload is installed and configured as described [here](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code).
+2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later).
 
 ## Step 1: Create a New MAUI Project
-
-### Visual Studio
 
 1. Go to **File > New > Project** and choose the **.NET MAUI App** template.
 2. Name the project and choose a location. Then, click **Next**.
 3. Select the .NET framework version and click **Create**.
 
-### Visual Studio Code
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit Package
+
+1. In **Solution Explorer,** right-click the project and choose **Manage NuGet Packages.**
+2. Search for [Syncfusion.Maui.Toolkit](https://www.nuget.org/packages/Syncfusion.Maui.Toolkit/) and install the latest version.
+3. Ensure the necessary dependencies are installed correctly, and the project is restored.
+
+## Step 3: Register the handler
+
+In the MauiProgram.cs file, register the handler for Syncfusion<sup>®</sup> Toolkit.
+
+{% tabs %}
+{% highlight C# tabtitle="MauiProgram.cs" hl_lines="1 9" %}
+using Syncfusion.Maui.Toolkit.Hosting;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .ConfigureSyncfusionToolkit()
+            .UseMauiApp<App>()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            });
+
+        return builder.Build();
+    }
+}
+
+{% endhighlight %}
+{% endtabs %}
+
+## Step 4: Add a Basic Numeric Entry
+
+Step 1. To initialize the control, import the `Syncfusion.Maui.Toolkit.NumericEntry` namespace into your code, as shown in the following code sample.
+
+{% tabs %}
+{% highlight xaml %}
+
+	<xmlns:editors="clr-namespace:Syncfusion.Maui.Toolkit.NumericEntry;assembly=Syncfusion.Maui.Toolkit"/>
+
+{% endhighlight %}
+{% highlight c# %}
+
+	using Syncfusion.Maui.Toolkit.NumericEntry;
+
+{% endhighlight %}
+{% endtabs %}
+
+Step 2: Add the [SfNumericEntry](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.NumericEntry.SfNumericEntry.html) control with a required optimal name using the included namespace.
+
+{% tabs %}
+{% highlight xaml %}
+
+	<editors:SfNumericEntry x:Name="numericEntry" />
+	
+{% endhighlight %}
+{% highlight C# %}
+
+    SfNumericEntry sfNumericEntry = new SfNumericEntry();   
+
+{% endhighlight %}
+{% endtabs %}
+
+{% endtabcontent %}
+{% tabcontent Visual Studio Code %}
+
+## Prerequisites
+
+Before proceeding, ensure the following are set up:
+
+1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later is installed.
+2. Set up a .NET MAUI environment with Visual Studio Code.
+3. Ensure that the .NET MAUI extension is installed and configured as described [here.](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code)
+
+## Step 1: Create a new .NET MAUI project
 
 1. Open the Command Palette by pressing **Ctrl+Shift+P** and type **.NET:New Project** and press Enter.
 2. Choose the **.NET MAUI App** template.
@@ -35,12 +114,6 @@ Before proceeding, ensure the following are in place:
 
 ## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit Package
 
-### Visual Studio
-1. In **Solution Explorer,** right-click the project and choose **Manage NuGet Packages.**
-2. Search for [Syncfusion.Maui.Toolkit](https://www.nuget.org/packages/Syncfusion.Maui.Toolkit/) and install the latest version.
-3. Ensure the necessary dependencies are installed correctly, and the project is restored.
-
-### Visual Studio Code
 1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
 2. Ensure you're in the project root directory where your .csproj file is located.
 3. Run the command `dotnet add package Syncfusion.Maui.Toolkit` to install the Syncfusion<sup>®</sup> .NET MAUI Toolkit NuGet package.
@@ -106,6 +179,9 @@ Step 2: Add the [SfNumericEntry](https://help.syncfusion.com/cr/maui-toolkit/Syn
 
 {% endhighlight %}
 {% endtabs %}
+
+{% endtabcontent %}
+{% endtabcontents %}
 
 ![.NET MAUI NumericEntry Application](GettingStarted_images/gettingStarted_img.png)
 

--- a/maui-toolkit/NumericUpDown/Getting-Started.md
+++ b/maui-toolkit/NumericUpDown/Getting-Started.md
@@ -11,7 +11,7 @@ documentation: ug
 
 This section guides you through setting up and configuring a [Numeric UpDown](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.NumericUpDown.SfNumericUpDown.html) in your .NET MAUI application. Follow the steps below to add a basic Numeric UpDown to your project.
 
-{% tabcontents %} 
+{% tabcontents %}
 {% tabcontent Visual Studio %}
 
 ## Prerequisites
@@ -181,7 +181,7 @@ Step 2: Add the [SfNumericUpDown](https://help.syncfusion.com/cr/maui-toolkit/Sy
 {% endtabs %}
 
 {% endtabcontent %}
-{% tabcontent Visual Studio Code %}
+{% endtabcontents %}
 
 ![.NET MAUI NumericUpDown Application](GettingStarted_images/gettingStarted_img.png)
 
@@ -210,9 +210,6 @@ sfNumericUpDown.CustomFormat = "0.000";
 
 {% endhighlight %}
 {% endtabs %}
-
-{% endtabcontent %}
-{% endtabcontents %}
 
 ![.NET MAUI NumericUpDown value editing](GettingStarted_images/editing_value.gif)
 

--- a/maui-toolkit/NumericUpDown/Getting-Started.md
+++ b/maui-toolkit/NumericUpDown/Getting-Started.md
@@ -101,10 +101,13 @@ Step 2: Add the [SfNumericUpDown](https://help.syncfusion.com/cr/maui-toolkit/Sy
 {% tabcontent Visual Studio Code %}
 ## Prerequisites
 
-Before proceeding, ensure the following are in place:
+## Prerequisites
 
-1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
-2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later)
+Before proceeding, ensure the following are set up:
+
+1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later is installed.
+2. Set up a .NET MAUI environment with Visual Studio Code.
+3. Ensure that the .NET MAUI extension is installed and configured as described [here.](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code)
 
 ## Step 1: Create a New MAUI Project
 

--- a/maui-toolkit/NumericUpDown/Getting-Started.md
+++ b/maui-toolkit/NumericUpDown/Getting-Started.md
@@ -11,7 +11,7 @@ documentation: ug
 
 This section guides you through setting up and configuring a [Numeric UpDown](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.NumericUpDown.SfNumericUpDown.html) in your .NET MAUI application. Follow the steps below to add a basic Numeric UpDown to your project.
 
-{% tabcontents %}
+{% tabcontents %} 
 {% tabcontent Visual Studio %}
 
 ## Prerequisites
@@ -19,7 +19,7 @@ This section guides you through setting up and configuring a [Numeric UpDown](ht
 Before proceeding, ensure the following are in place:
 
 1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
-2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later)
+2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later).
 
 ## Step 1: Create a New MAUI Project
 
@@ -29,7 +29,6 @@ Before proceeding, ensure the following are in place:
 
 ## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit Package
 
-### Visual Studio
 1. In **Solution Explorer,** right-click the project and choose **Manage NuGet Packages.**
 2. Search for [Syncfusion.Maui.Toolkit](https://www.nuget.org/packages/Syncfusion.Maui.Toolkit/) and install the latest version.
 3. Ensure the necessary dependencies are installed correctly, and the project is restored.
@@ -95,11 +94,8 @@ Step 2: Add the [SfNumericUpDown](https://help.syncfusion.com/cr/maui-toolkit/Sy
 {% endhighlight %}
 {% endtabs %}
 
-![.NET MAUI NumericUpDown Application](GettingStarted_images/gettingStarted_img.png)
-
 {% endtabcontent %}
 {% tabcontent Visual Studio Code %}
-## Prerequisites
 
 ## Prerequisites
 
@@ -109,7 +105,7 @@ Before proceeding, ensure the following are set up:
 2. Set up a .NET MAUI environment with Visual Studio Code.
 3. Ensure that the .NET MAUI extension is installed and configured as described [here.](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code)
 
-## Step 1: Create a New MAUI Project
+## Step 1: Create a New .NET MAUI Project
 
 1. Open the Command Palette by pressing **Ctrl+Shift+P** and type **.NET:New Project** and press Enter.
 2. Choose the **.NET MAUI App** template.
@@ -118,7 +114,6 @@ Before proceeding, ensure the following are set up:
 
 ## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit Package
 
-### Visual Studio Code
 1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
 2. Ensure you're in the project root directory where your .csproj file is located.
 3. Run the command `dotnet add package Syncfusion.Maui.Toolkit` to install the Syncfusion<sup>®</sup> .NET MAUI Toolkit NuGet package.
@@ -186,7 +181,7 @@ Step 2: Add the [SfNumericUpDown](https://help.syncfusion.com/cr/maui-toolkit/Sy
 {% endtabs %}
 
 {% endtabcontent %}
-{% endtabcontents %}
+{% tabcontent Visual Studio Code %}
 
 ![.NET MAUI NumericUpDown Application](GettingStarted_images/gettingStarted_img.png)
 
@@ -215,6 +210,9 @@ sfNumericUpDown.CustomFormat = "0.000";
 
 {% endhighlight %}
 {% endtabs %}
+
+{% endtabcontent %}
+{% endtabcontents %}
 
 ![.NET MAUI NumericUpDown value editing](GettingStarted_images/editing_value.gif)
 

--- a/maui-toolkit/NumericUpDown/Getting-Started.md
+++ b/maui-toolkit/NumericUpDown/Getting-Started.md
@@ -11,27 +11,21 @@ documentation: ug
 
 This section guides you through setting up and configuring a [Numeric UpDown](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.NumericUpDown.SfNumericUpDown.html) in your .NET MAUI application. Follow the steps below to add a basic Numeric UpDown to your project.
 
+{% tabcontents %}
+{% tabcontent Visual Studio %}
+
 ## Prerequisites
 
 Before proceeding, ensure the following are in place:
 
 1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
-2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later) or Visual Studio Code. For Visual Studio Code users, ensure that the .NET MAUI workload is installed and configured as described [here](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code).
+2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later)
 
 ## Step 1: Create a New MAUI Project
-
-### Visual Studio
 
 1. Go to **File > New > Project** and choose the **.NET MAUI App** template.
 2. Name the project and choose a location. Then, click **Next**.
 3. Select the .NET framework version and click **Create**.
-
-### Visual Studio Code
-
-1. Open the Command Palette by pressing **Ctrl+Shift+P** and type **.NET:New Project** and press Enter.
-2. Choose the **.NET MAUI App** template.
-3. Select the project location, type the project name and press Enter.
-4. Then choose **Create project**
 
 ## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit Package
 
@@ -39,6 +33,87 @@ Before proceeding, ensure the following are in place:
 1. In **Solution Explorer,** right-click the project and choose **Manage NuGet Packages.**
 2. Search for [Syncfusion.Maui.Toolkit](https://www.nuget.org/packages/Syncfusion.Maui.Toolkit/) and install the latest version.
 3. Ensure the necessary dependencies are installed correctly, and the project is restored.
+
+## Step 3: Register the handler
+
+In the MauiProgram.cs file, register the handler for Syncfusion<sup>®</sup> Toolkit.
+
+{% tabs %}
+{% highlight C# tabtitle="MauiProgram.cs" hl_lines="1 9" %}
+using Syncfusion.Maui.Toolkit.Hosting;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .ConfigureSyncfusionToolkit()
+            .UseMauiApp<App>()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            });
+
+        return builder.Build();
+    }
+}
+
+{% endhighlight %}
+{% endtabs %} 
+
+## Step 4: Add a Basic Numeric UpDown
+
+Step 1. To initialize the control, import the `Syncfusion.Maui.Toolkit.NumericUpDown` namespace into your code, as shown in the following code sample.
+
+{% tabs %}
+{% highlight xaml %}
+
+	<xmlns:editors="clr-namespace:Syncfusion.Maui.Toolkit.NumericUpDown;assembly=Syncfusion.Maui.Toolkit"/>
+
+{% endhighlight %}
+{% highlight c# %}
+
+	using Syncfusion.Maui.Toolkit.NumericUpDown;
+
+{% endhighlight %}
+{% endtabs %}
+
+Step 2: Add the [SfNumericUpDown](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.NumericUpDown.SfNumericUpDown.html) control with a required optimal name using the included namespace.
+
+{% tabs %}
+{% highlight xaml %}
+
+	<editors:SfNumericUpDown x:Name="numericUpDown" />
+	
+{% endhighlight %}
+{% highlight C# %}
+
+    SfNumericUpDown sfNumericUpDown = new SfNumericUpDown();   
+
+{% endhighlight %}
+{% endtabs %}
+
+![.NET MAUI NumericUpDown Application](GettingStarted_images/gettingStarted_img.png)
+
+{% endtabcontent %}
+{% tabcontent Visual Studio Code %}
+## Prerequisites
+
+Before proceeding, ensure the following are in place:
+
+1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
+2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later)
+
+## Step 1: Create a New MAUI Project
+
+1. Open the Command Palette by pressing **Ctrl+Shift+P** and type **.NET:New Project** and press Enter.
+2. Choose the **.NET MAUI App** template.
+3. Select the project location, type the project name and press Enter.
+4. Then choose **Create project**
+
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit Package
 
 ### Visual Studio Code
 1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
@@ -106,6 +181,9 @@ Step 2: Add the [SfNumericUpDown](https://help.syncfusion.com/cr/maui-toolkit/Sy
 
 {% endhighlight %}
 {% endtabs %}
+
+{% endtabcontent %}
+{% endtabcontents %}
 
 ![.NET MAUI NumericUpDown Application](GettingStarted_images/gettingStarted_img.png)
 

--- a/maui-toolkit/TextInputLayout/Getting-Started.md
+++ b/maui-toolkit/TextInputLayout/Getting-Started.md
@@ -12,12 +12,15 @@ keywords: .net maui text input layout, syncfusion text input layout, text input 
 
 This section guides you through setting up and configuring a [Text Input Layout](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.TextInputLayout.SfTextInputLayout.html) in your .NET MAUI application. Follow the steps below to add a basic TextInputLayout to your project.
 
+{% tabcontents %}
+{% tabcontent Visual Studio %}
+
 ## Prerequisites
 
 Before proceeding, ensure the following are in place:
 
  1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
- 2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later) or Visual Studio Code. For Visual Studio Code users, ensure that the .NET MAUI workload is installed and configured as described [here](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code).
+ 2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later)
 
 ## Step 1: Create a New MAUI Project
 
@@ -104,6 +107,106 @@ Add the following namespace to add [.NET MAUI Text Input Layout](https://help.sy
 ### Adding the .NET MAUI Text Input Layout control
 
 Add any input view control such as [Entry](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/entry) and [Editor](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/editor) controls and add hint label (floating label).
+
+{% tabcontents %}
+{% tabcontent Visual Studio %}
+
+
+## Prerequisites
+
+Before proceeding, ensure the following are in place:
+
+ 1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
+ 2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later)
+
+## Step 1: Create a New MAUI Project
+
+### Visual Studio
+
+ 1. Go to **File > New > Project** and choose the **.NET MAUI App** template.
+ 2. Name the project and choose a location. Then, click **Next**.
+ 3. Select the .NET framework version and click **Create**.
+
+### Visual Studio Code
+
+ 1. Open the Command Palette by pressing **Ctrl+Shift+P** and type **.NET:New Project** and press Enter.
+ 2. Choose the **.NET MAUI App** template.
+ 3. Select the project location, type the project name and press Enter.
+ 4. Then choose **Create project**
+
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit NuGet Package
+
+### Visual Studio
+
+ 1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
+ 2. Search for [Syncfusion.Maui.Toolkit](https://www.nuget.org/packages/Syncfusion.Maui.Toolkit/) and install the latest version.
+ 3. Ensure the necessary dependencies are installed correctly, and the project is restored.
+
+### Visual Studio Code
+
+1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
+2. Ensure you're in the project root directory where your .csproj file is located.
+3. Run the command `dotnet add package Syncfusion.Maui.Toolkit` to install the Syncfusion<sup>®</sup> .NET MAUI Toolkit NuGet package.
+4. To ensure all dependencies are installed, run `dotnet restore`.
+
+## Step 3: Register the Handler
+
+In the **MauiProgram.cs file**, register the handler for Syncfusion<sup>®</sup> Toolkit.
+
+{% tabs %}
+{% highlight C# tabtitle="MauiProgram.cs" hl_lines="1 9" %}    
+using Syncfusion.Maui.Toolkit.Hosting;
+
+public static class MauiProgram
+{
+	public static MauiApp CreateMauiApp()
+	{
+	    var builder = MauiApp.CreateBuilder();
+		builder
+			.ConfigureSyncfusionToolkit()
+			.UseMauiApp<App>()
+			.ConfigureFonts(fonts =>
+			{
+				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+			});
+
+		return builder.Build();
+	}
+}
+{% endhighlight %}
+{% endtabs %}
+
+## Step 4: Add a Basic TextInputLayout
+
+Step 1: Add the NuGet to the project as discussed in the above reference section.
+
+Step 2: Add the namespace as shown in the following code sample.
+
+Add the following namespace to add [.NET MAUI Text Input Layout](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.TextInputLayout.SfTextInputLayout.html).
+
+{% tabs %}
+
+{% highlight xaml %}
+
+    xmlns:inputLayout="clr-namespace:Syncfusion.Maui.Toolkit.TextInputLayout;assembly=Syncfusion.Maui.Toolkit"
+	
+{% endhighlight %}
+
+{% highlight c# %}
+
+    using Syncfusion.Maui.Toolkit.TextInputLayout;
+
+{% endhighlight %}
+
+{% endtabs %}
+
+### Adding the .NET MAUI Text Input Layout control
+
+Add any input view control such as [Entry](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/entry) and [Editor](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/editor) controls and add hint label (floating label).
+
+{% endtabcontent %}
+{% endtabcontents %}
 
 ## Initialize TextInputLayout
 

--- a/maui-toolkit/TextInputLayout/Getting-Started.md
+++ b/maui-toolkit/TextInputLayout/Getting-Started.md
@@ -91,7 +91,7 @@ Add the following namespace to add [.NET MAUI Text Input Layout](https://help.sy
 Add any input view control such as [Entry](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/entry) and [Editor](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/editor) controls and add hint label (floating label).
 
 {% endtabcontent %}
-{% tabcontent Visual Studio COde%}
+{% tabcontent Visual Studio Code%}
 
 
 ## Prerequisites

--- a/maui-toolkit/TextInputLayout/Getting-Started.md
+++ b/maui-toolkit/TextInputLayout/Getting-Started.md
@@ -24,33 +24,15 @@ Before proceeding, ensure the following are in place:
 
 ## Step 1: Create a New MAUI Project
 
-### Visual Studio
-
  1. Go to **File > New > Project** and choose the **.NET MAUI App** template.
  2. Name the project and choose a location. Then, click **Next**.
  3. Select the .NET framework version and click **Create**.
 
-### Visual Studio Code
-
- 1. Open the Command Palette by pressing **Ctrl+Shift+P** and type **.NET:New Project** and press Enter.
- 2. Choose the **.NET MAUI App** template.
- 3. Select the project location, type the project name and press Enter.
- 4. Then choose **Create project**
-
 ## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit NuGet Package
-
-### Visual Studio
 
  1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
  2. Search for [Syncfusion.Maui.Toolkit](https://www.nuget.org/packages/Syncfusion.Maui.Toolkit/) and install the latest version.
  3. Ensure the necessary dependencies are installed correctly, and the project is restored.
-
-### Visual Studio Code
-
-1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
-2. Ensure you're in the project root directory where your .csproj file is located.
-3. Run the command `dotnet add package Syncfusion.Maui.Toolkit` to install the Syncfusion<sup>®</sup> .NET MAUI Toolkit NuGet package.
-4. To ensure all dependencies are installed, run `dotnet restore`.
 
 ## Step 3: Register the Handler
 
@@ -114,20 +96,13 @@ Add any input view control such as [Entry](https://learn.microsoft.com/en-us/dot
 
 ## Prerequisites
 
-Before proceeding, ensure the following are in place:
+Before proceeding, ensure the following are set up:
 
- 1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
- 2. Set up a .NET MAUI environment with Visual Studio 2022 (v17.8 or later)
+1. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later is installed.
+2. Set up a .NET MAUI environment with Visual Studio Code.
+3. Ensure that the .NET MAUI extension is installed and configured as described [here.](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-8.0&tabs=visual-studio-code)
 
 ## Step 1: Create a New MAUI Project
-
-### Visual Studio
-
- 1. Go to **File > New > Project** and choose the **.NET MAUI App** template.
- 2. Name the project and choose a location. Then, click **Next**.
- 3. Select the .NET framework version and click **Create**.
-
-### Visual Studio Code
 
  1. Open the Command Palette by pressing **Ctrl+Shift+P** and type **.NET:New Project** and press Enter.
  2. Choose the **.NET MAUI App** template.
@@ -135,14 +110,6 @@ Before proceeding, ensure the following are in place:
  4. Then choose **Create project**
 
 ## Step 2: Install the Syncfusion<sup>®</sup> MAUI Toolkit NuGet Package
-
-### Visual Studio
-
- 1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
- 2. Search for [Syncfusion.Maui.Toolkit](https://www.nuget.org/packages/Syncfusion.Maui.Toolkit/) and install the latest version.
- 3. Ensure the necessary dependencies are installed correctly, and the project is restored.
-
-### Visual Studio Code
 
 1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
 2. Ensure you're in the project root directory where your .csproj file is located.

--- a/maui-toolkit/TextInputLayout/Getting-Started.md
+++ b/maui-toolkit/TextInputLayout/Getting-Started.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with .NET MAUI Text Input Layout control | Syncfusion<sup>®</sup>
+title: Getting Started with .NET MAUI Text Input Layout | Syncfusion<sup>®</sup>
 description: Learn here about getting started with Syncfusion<sup>®</sup> .NET MAUI Text Input Layout (SfTextInputLayout) control, its elements and more.
 platform: maui-toolkit
 control: SfTextInputLayout

--- a/maui-toolkit/TextInputLayout/Getting-Started.md
+++ b/maui-toolkit/TextInputLayout/Getting-Started.md
@@ -90,8 +90,8 @@ Add the following namespace to add [.NET MAUI Text Input Layout](https://help.sy
 
 Add any input view control such as [Entry](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/entry) and [Editor](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/editor) controls and add hint label (floating label).
 
-{% tabcontents %}
-{% tabcontent Visual Studio %}
+{% endtabcontent %}
+{% tabcontent Visual Studio COde%}
 
 
 ## Prerequisites

--- a/maui-toolkit/TextInputLayout/Getting-Started.md
+++ b/maui-toolkit/TextInputLayout/Getting-Started.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with .NET MAUI Text Input Layout | Syncfusion<sup>®</sup>
+title: Getting Started with .NET MAUI Text Input Layout | Syncfusion®
 description: Learn here about getting started with Syncfusion<sup>®</sup> .NET MAUI Text Input Layout (SfTextInputLayout) control, its elements and more.
 platform: maui-toolkit
 control: SfTextInputLayout


### PR DESCRIPTION
I have added tab support for Visual Studio and Visual Studio code in toolkit getting started page for the following controls

- SfButton
- SfCarousel
- SfChip
- SfNumericEntry
- SfNumericUpdown
- SfTextInputLayout