### PR TITLE
Fixes duplicate namespace declerations

### DIFF
--- a/maui-toolkit/Expander/getting-started.md
+++ b/maui-toolkit/Expander/getting-started.md
@@ -70,7 +70,7 @@ public class MauiProgram
 {% tabs %}
 {% highlight xaml hl_lines="4" %}
 <ContentPage   
-    xmlns:syncfusion=xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.Expander;assembly=Syncfusion.Maui.Toolkit">
+    xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.Expander;assembly=Syncfusion.Maui.Toolkit">
     <syncfusion:SfExpander />
 </ContentPage>
 {% endhighlight %}
@@ -151,7 +151,7 @@ public class MauiProgram
 {% tabs %}
 {% highlight xaml hl_lines="4" %}
 <ContentPage   
-    xmlns:syncfusion=xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.Expander;assembly=Syncfusion.Maui.Toolkit">
+    xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.Expander;assembly=Syncfusion.Maui.Toolkit">
     <syncfusion:SfExpander />
 </ContentPage>
 {% endhighlight %}
@@ -231,7 +231,7 @@ public class MauiProgram
 {% tabs %}
 {% highlight xaml hl_lines="4" %}
 <ContentPage   
-    xmlns:syncfusion=xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.Expander;assembly=Syncfusion.Maui.Toolkit">
+    xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.Expander;assembly=Syncfusion.Maui.Toolkit">
     <syncfusion:SfExpander />
 </ContentPage>
 {% endhighlight %}

--- a/maui-toolkit/Pull-to-Refresh/getting-started.md
+++ b/maui-toolkit/Pull-to-Refresh/getting-started.md
@@ -70,7 +70,7 @@ public class MauiProgram
 {% tabs %}
 {% highlight xaml hl_lines="4" %}
 <ContentPage   
-    xmlns:syncfusion=xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.PullToRefresh;assembly=Syncfusion.Maui.Toolkit">
+    xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.PullToRefresh;assembly=Syncfusion.Maui.Toolkit">
     <syncfusion:SfPullToRefresh />
 </ContentPage>
 {% endhighlight %}
@@ -151,7 +151,7 @@ public class MauiProgram
 {% tabs %}
 {% highlight xaml hl_lines="4" %}
 <ContentPage   
-    xmlns:syncfusion=xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.PullToRefresh;assembly=Syncfusion.Maui.Toolkit">
+    xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.PullToRefresh;assembly=Syncfusion.Maui.Toolkit">
     <syncfusion:SfPullToRefresh />
 </ContentPage>
 {% endhighlight %}
@@ -231,7 +231,7 @@ public class MauiProgram
 {% tabs %}
 {% highlight xaml hl_lines="4" %}
 <ContentPage   
-    xmlns:syncfusion=xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.PullToRefresh;assembly=Syncfusion.Maui.Toolkit">
+    xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.PullToRefresh;assembly=Syncfusion.Maui.Toolkit">
     <syncfusion:SfPullToRefresh />
 </ContentPage>
 {% endhighlight %}


### PR DESCRIPTION
There are a few places where getting started guides list the sample as

```xml
<ContentPage   
    xmlns:syncfusion=xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.Expander;assembly=Syncfusion.Maui.Toolkit">
```

but `xmlns:syncfusion=xmlns:syncfusion="` is incorrect.

I checked for other instances of `=xmlns` but could not find any so I assume these six places are the only places with the issue.