### PR TITLE
SEO-204825-Maui-Toolkit-Description-Too-Short-Hotfix 

### DIFF
--- a/maui-toolkit/TabView/Tab-Bar-Customization.md
+++ b/maui-toolkit/TabView/Tab-Bar-Customization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Customize the Tab Bar in .NET MAUI Tab View (SfTabView) | Syncfusion®
-description: Learn how to customize the header in Syncfusion® .NET MAUI Tab View (SfTabView) control.
+description: Check out and learn here how to customize the header in Syncfusion® .NET MAUI Tab View (SfTabView) control.
 platform: maui-toolkit
 control: SfTabView
 documentation: UG


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Description too short|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Meta description| Meta description was too short. SEO rule says it should be 100+ characters, so I changed it.|



Regards, 
Asha