### PR TITLE
SEO-204825-Maui-Duplicate-Description-Hotfix

### DIFF
--- a/maui-toolkit/Cartesian-Charts/Getting-Started.md
+++ b/maui-toolkit/Cartesian-Charts/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Getting started with .NET MAUI Chart control | Syncfusion
-description: This section explains about the getting started with Syncfusion® MAUI Chart (SfCartesianChart) control.
+description: Learn how this section explains about the getting started with Syncfusion® MAUI Chart (SfCartesianChart) control.
 platform: maui-toolkit
 control: SfCartesianChart
 documentation: ug


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Duplicate description|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Meta description| SEO rules say not to use the same description on multiple pages, so I changed it.|



Regards, 
Asha