### PR TITLE
Updated on Cartesian Chart Trackball UG Content

### DIFF
--- a/maui-toolkit/Cartesian-Charts/Trackball.md
+++ b/maui-toolkit/Cartesian-Charts/Trackball.md
@@ -561,7 +561,7 @@ this.Content = chart;
 
 ### TrackballCreated
 
-The [`TrackballCreated`](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Charts.SfCartesianChart.html#Syncfusion_Maui_Toolkit_Charts_SfCartesianChart_TrackballCreated) event occurs when the trackball moves from one data point to another. This argument contains an object of the ChartPointsInfo. The following properties are available in the `ChartPointInfo` class to customize the appearance of the trackball label based on a condition.
+The [`TrackballCreated`](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Charts.SfCartesianChart.html#Syncfusion_Maui_Toolkit_Charts_SfCartesianChart_TrackballCreated) event occurs when the trackball moves from one data point to another. This argument contains an object of the `TrackballPointInfo`. The following properties are available in the [TrackballPointInfo](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Charts.TrackballPointInfo.html) class to customize the appearance of the trackball label based on a condition.
 
 * [Label](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Charts.TrackballPointInfo.html#Syncfusion_Maui_Toolkit_Charts_TrackballPointInfo_Label) of type `string`: Used to change the text of the trackball label.
 * [LabelStyle](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Charts.TrackballPointInfo.html#Syncfusion_Maui_Toolkit_Charts_TrackballPointInfo_LabelStyle) of type `ChartLabelStyle`: Used to customize the appearance of the trackball label.


### PR DESCRIPTION
This PR update the TrackballCreated event argument object class name from **ChartPointsInfo** to **TrackballPointInfo** in SfCartesianChart UG document. Also added the **API reference** link TrackballPointInfo class

[TrackballPointInfo](https://help.syncfusion.com/cr/maui-toolkit/Syncfusion.Maui.Toolkit.Charts.TrackballPointInfo.html)

