### PR TITLE
[hotfix] Updated the icons for globalization  details

### DIFF
--- a/maui-toolkit/images/full-support.svg
+++ b/maui-toolkit/images/full-support.svg
@@ -1,11 +1,11 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_1_28)">
+<g clip-path="url(#clip0_1_44)">
 <path d="M24 0H0V24H24V0Z" fill="white"/>
-<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#DDFFCB" stroke="#DDFFCB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.5 12L10.5 15L16.5 9" stroke="#039926" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#28AC61" stroke="#28AC61" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 12L10.5 15L16.5 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </g>
 <defs>
-<clipPath id="clip0_1_28">
+<clipPath id="clip0_1_44">
 <rect width="24" height="24" fill="white"/>
 </clipPath>
 </defs>

--- a/maui-toolkit/images/no-support.svg
+++ b/maui-toolkit/images/no-support.svg
@@ -1,11 +1,11 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_1_32)">
+<g clip-path="url(#clip0_1_48)">
 <path d="M24 0H0V24H24V0Z" fill="white"/>
-<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#FFE9E5" stroke="#FFE9E5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M15 9L9 15M9 9L15 15" stroke="#C70101" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#DE553D" stroke="#DE553D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 9L9 15M9 9L15 15" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </g>
 <defs>
-<clipPath id="clip0_1_32">
+<clipPath id="clip0_1_48">
 <rect width="24" height="24" fill="white"/>
 </clipPath>
 </defs>

--- a/maui-toolkit/images/not-applicable.svg
+++ b/maui-toolkit/images/not-applicable.svg
@@ -1,10 +1,10 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_1_17)">
+<g clip-path="url(#clip0_1_37)">
 <path d="M24 0H0V24H24V0Z" fill="white"/>
 <path d="M4.93 4.93L19.07 19.07M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z" stroke="#516685" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </g>
 <defs>
-<clipPath id="clip0_1_17">
+<clipPath id="clip0_1_37">
 <rect width="24" height="24" fill="white"/>
 </clipPath>
 </defs>

--- a/maui-toolkit/images/partial-support.svg
+++ b/maui-toolkit/images/partial-support.svg
@@ -1,11 +1,10 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_1_24)">
-<path d="M24 0H0V24H24V0Z" fill="white"/>
-<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#FFE9CA" stroke="#FFE9CA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M8 12H16" stroke="#BA7B05" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<g clip-path="url(#clip0_1_40)">
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#D5950A" stroke="#D5950A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 12H16" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </g>
 <defs>
-<clipPath id="clip0_1_24">
+<clipPath id="clip0_1_40">
 <rect width="24" height="24" fill="white"/>
 </clipPath>
 </defs>


### PR DESCRIPTION
**Reason:**
Updated the icons for globalization  details

**Preview:**
<img width="1087" height="780" alt="Screenshot 2026-08-14 181432" src="https://github.com/user-attachments/assets/b7cb9428-f384-43f9-a26e-571d319c3229" />
